### PR TITLE
fix(ssh2https): Move from SSH to HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
 		"fluent-ffmpeg": "^2.0.0-rc2",
 		"fs-extra": "~0.12.0",
 
-		"node-lib": "git+ssh://git@github.com:Sagacify/node-lib.git#worker",
-		"sg-files-system": "git+ssh://git@github.com:Sagacify/sg-files-system.git",
-		"sg-messaging-server": "git+ssh://git@github.com:Sagacify/sg-messaging-server.git"
+		"node-lib": "git+https://github.com/Sagacify/node-lib.git#worker",
+		"sg-files-system": "git+https://github.com/Sagacify/sg-files-system.git",
+		"sg-messaging-server": "git+https://github.com/Sagacify/sg-messaging-server.git"
 	}
 }


### PR DESCRIPTION
Remove usage of SSH in package.json to avoid SSH key in dockefiles
